### PR TITLE
Ignore declaration null

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,11 @@ export default function stub(options={}) {
 
       ast.body.forEach(node => {
         if (node.type === 'ExportNamedDeclaration') {
+          // Handle null declarations
+          // Example: `export { varName as default };`
+          if (node.declaration == null) {
+          	return;
+          }
           // Collect binding names and ensure we can reassign them.
           if (node.declaration.type === 'VariableDeclaration') {
             if (node.declaration.kind === 'const') {

--- a/test/examples/export-default-brackets/main.js
+++ b/test/examples/export-default-brackets/main.js
@@ -1,0 +1,4 @@
+function fn() {
+  return 0;
+}
+export {fn as default};

--- a/test/stub_test.js
+++ b/test/stub_test.js
@@ -84,4 +84,13 @@ describe('stub', () => {
       eq(module.exports.oneAfterReset, 1);
     });
   });
+
+  it('does not throw on `export {varName as default}``', () => {
+    return rollup({
+      entry: 'test/examples/export-default-brackets/main.js',
+      plugins: [
+        stub({ include: 'test/examples/export-default-brackets/main.js' })
+      ]
+    });
+  });
 });


### PR DESCRIPTION
Fixes a problem where node.declaration == null would throw on `if (node.declaration.type === 'VariableDeclaration')` (line 31)